### PR TITLE
feat: ツイート投稿に画像添付を対応、新TweetDtoおよび表示ロジックを追加

### DIFF
--- a/src/main/java/com/yotsuba/bocchi/Media.java
+++ b/src/main/java/com/yotsuba/bocchi/Media.java
@@ -1,0 +1,72 @@
+package com.yotsuba.bocchi;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.util.Date;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Media {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String fileName;
+    private String contentType;
+    @Lob
+    @Column(columnDefinition = "LONGBLOB")
+    private byte[] data;
+    @CreatedDate
+    private Date created;
+    @ManyToOne
+    @JoinColumn(name = "tweet_id")
+    private Tweet tweet;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public Tweet getTweet() {
+        return tweet;
+    }
+
+    public void setTweet(Tweet tweet) {
+        this.tweet = tweet;
+    }
+}

--- a/src/main/java/com/yotsuba/bocchi/MediaController.java
+++ b/src/main/java/com/yotsuba/bocchi/MediaController.java
@@ -1,0 +1,28 @@
+package com.yotsuba.bocchi;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/media")
+public class MediaController {
+    private final MediaService mediaService;
+
+    public MediaController(MediaService mediaService) {
+        this.mediaService = mediaService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<byte[]> getMedia(@PathVariable Long id) {
+        return mediaService.findById(id)
+                .map(media -> {
+                    HttpHeaders headers = new HttpHeaders();
+                    headers.setContentType(MediaType.parseMediaType(media.getContentType()));
+                    return new ResponseEntity<>(media.getData(), headers, HttpStatus.OK);
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/yotsuba/bocchi/MediaRepository.java
+++ b/src/main/java/com/yotsuba/bocchi/MediaRepository.java
@@ -1,0 +1,6 @@
+package com.yotsuba.bocchi;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MediaRepository extends JpaRepository<Media, Long> {
+}

--- a/src/main/java/com/yotsuba/bocchi/MediaService.java
+++ b/src/main/java/com/yotsuba/bocchi/MediaService.java
@@ -1,0 +1,23 @@
+package com.yotsuba.bocchi;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class MediaService {
+    private final MediaRepository mediaRepository;
+
+    public MediaService(MediaRepository mediaRepository) {
+        this.mediaRepository = mediaRepository;
+    }
+
+    public Optional<Media> findById(Long id) {
+        return mediaRepository.findById(id);
+    }
+
+    public void saveAll(List<Media> mediaList) {
+        mediaRepository.saveAll(mediaList);
+    }
+}

--- a/src/main/java/com/yotsuba/bocchi/Tweet.java
+++ b/src/main/java/com/yotsuba/bocchi/Tweet.java
@@ -5,6 +5,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.Date;
+import java.util.List;
+import java.util.ArrayList;
 
 @Entity
 @Table(name = "tweets")
@@ -18,6 +20,9 @@ public class Tweet {
     private String text;
     @CreatedDate
     private Date created;
+
+    @OneToMany(mappedBy = "tweet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Media> mediaList = new ArrayList<>();
 
     public Integer getId() {
         return id;
@@ -49,5 +54,13 @@ public class Tweet {
 
     public void setCreated(Date created) {
         this.created = created;
+    }
+
+    public List<Media> getMediaList() {
+        return mediaList;
+    }
+
+    public void setMediaList(List<Media> mediaList) {
+        this.mediaList = mediaList;
     }
 }

--- a/src/main/java/com/yotsuba/bocchi/TweetController.java
+++ b/src/main/java/com/yotsuba/bocchi/TweetController.java
@@ -1,6 +1,8 @@
 package com.yotsuba.bocchi;
 
 import com.yotsuba.bocchi.dto.TweetDto;
+import org.springframework.http.MediaType;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -39,10 +41,32 @@ public class TweetController {
         return tweetService.findUserAllTweetSummary(userId);
     }
 
-    @PostMapping
-    public void saveTweet(@RequestBody TweetRequest tweetRequest) {
-        tweetService.saveTweet(tweetRequest);
+    // 旧API: JSON形式でのTweet投稿（メディア無し）
+    // @PostMapping
+    // public void saveTweet(@RequestBody TweetRequest tweetRequest) {
+    //     tweetService.saveTweet(tweetRequest);
+    // }
 
+    // 新API: multipart/form-data形式でテキストとファイルの両方を受信
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public void saveTweetWithMedia(
+            @RequestParam("userId") String userId,
+            @RequestParam("text") String text,
+            @RequestPart(value = "mediaFiles", required = false) List<MultipartFile> mediaFiles
+    ) {
+        System.out.println("ユーザーID: " + userId);
+        System.out.println("テキスト: " + text);
+        if (mediaFiles != null) {
+            System.out.println("受信したファイル数: " + mediaFiles.size());
+            for (MultipartFile file : mediaFiles) {
+                System.out.println("ファイル名: " + file.getOriginalFilename());
+            }
+        } else {
+            System.out.println("添付ファイルなし");
+        }
+
+        // サービス側にファイル付きTweetを渡す処理を呼び出す
+        tweetService.saveTweetWithMedia(userId, text, mediaFiles);
     }
 
     @DeleteMapping

--- a/src/main/java/com/yotsuba/bocchi/TweetRepository.java
+++ b/src/main/java/com/yotsuba/bocchi/TweetRepository.java
@@ -8,14 +8,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface TweetRepository extends JpaRepository<Tweet, Integer> {
-    @Query(value = "SELECT new com.yotsuba.bocchi.dto.TweetDto(t.id,t.user.name,t.text,t.created)" + "FROM Tweet AS t ORDER BY t.created ASC")
-    List<TweetDto> findAllTweetSummary();
-
-    @Query(value = "SELECT new com.yotsuba.bocchi.dto.TweetDto(t.id,t.user.name, t.text, t.created) " +
-            "FROM Tweet AS t " +
-            "WHERE t.user.id = :user_id " +
-            "ORDER BY t.created ASC")
-    List<TweetDto> findUserAllTweetSummary(@Param("user_id")String userId);
-
-
+    List<Tweet> findAllByOrderByCreatedAsc();
+    List<Tweet> findByUser_IdOrderByCreatedAsc(String userId);
 }

--- a/src/main/java/com/yotsuba/bocchi/TweetService.java
+++ b/src/main/java/com/yotsuba/bocchi/TweetService.java
@@ -7,15 +7,22 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.io.IOException;
+import org.springframework.web.multipart.MultipartFile;
+import com.yotsuba.bocchi.Media;
+import com.yotsuba.bocchi.MediaRepository;
 
 @Service
 public class TweetService {
     private final TweetRepository tweetRepository;
     private final UserRepository userRepository;
+    private final MediaRepository mediaRepository;
 
-    public TweetService(TweetRepository tweetRepository, UserRepository userRepository) {
+    public TweetService(TweetRepository tweetRepository, UserRepository userRepository, MediaRepository mediaRepository) {
         this.tweetRepository = tweetRepository;
         this.userRepository = userRepository;
+        this.mediaRepository = mediaRepository;
     }
 
     public List<Tweet> findAll() {
@@ -23,11 +30,35 @@ public class TweetService {
     }
 
     public List<TweetDto> findAllTweetSummary() {
-        return tweetRepository.findAllTweetSummary();
+        List<Tweet> tweets = tweetRepository.findAllByOrderByCreatedAsc();
+        return tweets.stream().map(tweet -> {
+            List<Long> mediaIds = tweet.getMediaList().stream()
+                .map(Media::getId)
+                .toList();
+            return new TweetDto(
+                tweet.getId(),
+                tweet.getUser().getName(),
+                tweet.getText(),
+                tweet.getCreated(),
+                mediaIds
+            );
+        }).toList();
     }
 
     public List<TweetDto> findUserAllTweetSummary(String userId) {
-        return tweetRepository.findUserAllTweetSummary(userId);
+        List<Tweet> tweets = tweetRepository.findByUser_IdOrderByCreatedAsc(userId);
+        return tweets.stream().map(tweet -> {
+            List<Long> mediaIds = tweet.getMediaList().stream()
+                .map(Media::getId)
+                .toList();
+            return new TweetDto(
+                tweet.getId(),
+                tweet.getUser().getName(),
+                tweet.getText(),
+                tweet.getCreated(),
+                mediaIds
+            );
+        }).toList();
     }
 
     public void saveTweet(TweetRequest tweetRequest) {
@@ -39,7 +70,33 @@ public class TweetService {
         System.out.println("tweet.getCreated():" + tweet.getCreated());
         System.out.println("tweet.getUser().getName():" + tweet.getUser().getName());
         tweetRepository.save(tweet);
+    }
 
+    // 新しいメディア対応のTweet保存処理
+    // mediaFiles が null/空の場合も考慮
+    public void saveTweetWithMedia(String userId, String text, List<MultipartFile> mediaFiles) {
+        Tweet tweet = new Tweet();
+        tweet.setText(text);
+        User user = userRepository.findById(userId).orElseThrow();
+        tweet.setUser(user);
+        tweetRepository.save(tweet);
+
+        if (mediaFiles != null && !mediaFiles.isEmpty()) {
+            List<Media> mediaList = new ArrayList<>();
+            for (MultipartFile file : mediaFiles) {
+                try {
+                    Media media = new Media();
+                    media.setFileName(file.getOriginalFilename());
+                    media.setContentType(file.getContentType());
+                    media.setData(file.getBytes());
+                    media.setTweet(tweet);
+                    mediaList.add(media);
+                } catch (IOException e) {
+                    System.err.println("ファイル読み込みエラー: " + e.getMessage());
+                }
+            }
+            mediaRepository.saveAll(mediaList);
+        }
     }
 
     public void deleteTweet(Integer tweetId) {

--- a/src/main/java/com/yotsuba/bocchi/dto/TweetDto.java
+++ b/src/main/java/com/yotsuba/bocchi/dto/TweetDto.java
@@ -1,18 +1,29 @@
 package com.yotsuba.bocchi.dto;
 
 import java.util.Date;
+import java.util.List;
 
 public class TweetDto {
     private Integer id;
     private String name;
     private String text;
     private Date created;
+    private List<Long> mediaIds;
 
     public TweetDto(Integer id, String name, String text, Date created) {
         this.id = id;
         this.name = name;
         this.text = text;
         this.created = created;
+        this.mediaIds = null;
+    }
+
+    public TweetDto(Integer id, String name, String text, Date created, List<Long> mediaIds) {
+        this.id = id;
+        this.name = name;
+        this.text = text;
+        this.created = created;
+        this.mediaIds = mediaIds;
     }
 
     public Integer getId() {
@@ -29,6 +40,10 @@ public class TweetDto {
 
     public Date getCreated() {
         return created;
+    }
+
+    public List<Long> getMediaIds() {
+        return mediaIds;
     }
 
 }

--- a/src/main/java/com/yotsuba/bocchi/security/MySecurityConfig.java
+++ b/src/main/java/com/yotsuba/bocchi/security/MySecurityConfig.java
@@ -68,6 +68,7 @@ public class MySecurityConfig {
                                 "/api/authentication/signup",
                                 "/api/authentication/login",
                                 "/api/tweets",
+                                "/api/media/**",
                                 "/error"
                         ).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,8 +3,10 @@ logging:
     #    org.hibernate.SQL: debug
     org.hibernate.type: trace
     org.hibernate.orm.jdbc.bind: trace
-    org.hibernate.orm.jdbc.extract: trace
-    org.springframework.security: trace
+#    org.hibernate.orm.jdbc.extract: trace
+    org.hibernate.orm.jdbc.extract: info
+#    org.springframework.security: trace
+    org.springframework.security: info
 spring:
   datasource:
     # Database connection URL


### PR DESCRIPTION
- Tweet に関連する Media エンティティを追加し、画像ファイルの保存に対応
- multipart/form-data によるメディア付きツイート投稿を新規にサポート
- TweetService に saveTweetWithMedia を追加し、MediaRepository 経由でバイナリ保存
- TweetDto に mediaIds フィールドを追加し、フロントへ画像IDを提供
- API `/api/tweets` の POST を multipart 形式に変更
- TweetRepository の JPQL を廃止し、エンティティごとの取得に変更（mediaList含むため）
- MediaController で `/api/media/{id}` による画像取得APIを提供（公開）
- TweetItem.vue を作成し、Tweet 表示を共通コンポーネント化、画像表示に対応
- TweetContainer.vue / MyTweetContainer.vue をリファクタリングし、TweetItem を使用
- TweetForm.vue を更新し、画像アップロードフィールドおよび FormData に対応
- changelog に media テーブル追加を反映