### PR TITLE
ユーザーアバター機能追加

### DIFF
--- a/src/main/java/com/yotsuba/bocchi/User.java
+++ b/src/main/java/com/yotsuba/bocchi/User.java
@@ -1,9 +1,6 @@
 package com.yotsuba.bocchi;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -20,6 +17,10 @@ public class User {
     private String password;
     @CreatedDate
     private Date created;
+    @Lob
+    @Column(columnDefinition = "LONGBLOB")
+    private byte[] avatar;
+    private String avatarContentType;
 
     private static final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
@@ -61,5 +62,21 @@ public class User {
 
     public void setCreated(Date created) {
         this.created = created;
+    }
+
+    public byte[] getAvatar() {
+        return avatar;
+    }
+
+    public void setAvatar(byte[] avatar) {
+        this.avatar = avatar;
+    }
+
+    public String getAvatarContentType() {
+        return avatarContentType;
+    }
+
+    public void setAvatarContentType(String avatarContentType) {
+        this.avatarContentType = avatarContentType;
     }
 }

--- a/src/main/java/com/yotsuba/bocchi/UserController.java
+++ b/src/main/java/com/yotsuba/bocchi/UserController.java
@@ -1,0 +1,44 @@
+package com.yotsuba.bocchi;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+    @Autowired
+    private UserService userService;
+
+    @GetMapping("/avatar/{userId}")
+    public ResponseEntity<byte[]> getAvatar(@PathVariable String userId) {
+        UserService.AvatarData avatarData = userService.getAvatar(userId);
+
+        if (avatarData.data() == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+
+
+        HttpHeaders headers = new HttpHeaders();
+        String contentType = avatarData.contentType();
+        if (contentType == null || contentType.isBlank()) {
+            contentType = "image/jpeg";
+        }
+        headers.setContentType(MediaType.parseMediaType(contentType));
+        return new ResponseEntity<>(avatarData.data(), headers, HttpStatus.OK);
+    }
+
+    @PostMapping(value = "/avatar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public void uploadAvatar(@RequestParam("userId") String userId,
+                             @RequestPart("avatar") MultipartFile file) throws IOException {
+        userService.saveAvatar(userId, file);
+    }
+}

--- a/src/main/java/com/yotsuba/bocchi/UserService.java
+++ b/src/main/java/com/yotsuba/bocchi/UserService.java
@@ -2,6 +2,9 @@ package com.yotsuba.bocchi;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Service
 public class UserService {
@@ -27,4 +30,20 @@ public class UserService {
         System.out.println(userRepository.findById(id)+"だった");
         return userRepository.findById(id).orElse(null) != null;
     }
+
+    public record AvatarData(byte[] data, String contentType) {}
+
+    public AvatarData getAvatar(String userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        return new AvatarData(user.getAvatar(), user.getAvatarContentType());
+    }
+
+    public void saveAvatar(String userId, MultipartFile file) throws IOException {
+        User user = userRepository.findById(userId).orElseThrow();
+        user.setAvatarContentType(file.getContentType());
+        user.setAvatar(file.getBytes());
+        userRepository.save(user);
+    }
+
+
 }


### PR DESCRIPTION
- ユーザーのプロフィール画像（アバター）をアップロード・表示できるように変更
- `User` エンティティに `avatar` と `avatarContentType` カラムを追加
- `UserService` にアップロード・取得ロジックを実装
- `/api/user/avatar` POST/GET API を追加
- `MyPageMain.vue` にアイコン表示・アップロードUIを追加
- Liquibaseの `users.xml` に対応カラムを追加